### PR TITLE
updated Editor styles to include bottom margin buffer

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -274,6 +274,7 @@ export default ({ children }) => {
               <Editor
                 fontSize={12}
                 sx={{
+                  marginBottom: '64px',
                   "& * > label": {
                     color: `graySecondary`,
                   },


### PR DESCRIPTION
Editor footer is currently covering up the spacing section: 
![image](https://user-images.githubusercontent.com/20845740/71689474-01679300-2d9a-11ea-8c11-a489de3ca883.png)

So I've added a small, `64px` buffer to the `Editor`, to match your `calc(100vh - 64px)` height for the container `Box`.